### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ WebTest
 amqplib
 anyjson
 billiard
-celery
+celery==3.0.24
 cracklib
 decorator
 distribute


### PR DESCRIPTION
Celery 3.1 was released on 11/13 and breaks new installs of baruwa. The whole directory structure is different.
