### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ pyparsing<2.0
 pyrad
 python-ldap
 -e git://github.com/ahupp/python-magic.git@d033eb46a8ace66cf795c54168a197228e47ce9e#egg=python_magic-dev
-reportlab
+reportlab==2.7
 repoze.lru
 repoze.what==1.0.9
 repoze.what-pylons==1.0


### PR DESCRIPTION
reportlab 3.0 requires Python 2.7+ or 3.3+; 3.0-3.2 are not supported. Python 2.7 is not in public repo's and requires a compile for RH/CentOS.
